### PR TITLE
Improves for Majordomo Executus encounter

### DIFF
--- a/monkey-tail.py
+++ b/monkey-tail.py
@@ -70,8 +70,9 @@ def fix_segmenting_start(log_entry, writer):
 
 
 def fix_segmenting_end(log_entry, writer):
+    # 0xa18 — specific flag for Majordomo Executus's ends of encounter (not sure)
     for boss in boss_data:
-        if not boss.encounter_end_found and "UNIT_DIED" in log_entry and "\""+boss.name+"\"" in log_entry:
+        if not boss.encounter_end_found and ("UNIT_DIED" in log_entry or "0xa18" in log_entry) and "\""+boss.name+"\"" in log_entry:
             write_segment_end(log_entry, boss, writer)
             boss.encounter_end_found = True
 

--- a/monkey-tail.py
+++ b/monkey-tail.py
@@ -72,7 +72,7 @@ def fix_segmenting_start(log_entry, writer):
 def fix_segmenting_end(log_entry, writer):
     # 0xa18 — specific flag for Majordomo Executus's ends of encounter (not sure)
     for boss in boss_data:
-        if not boss.encounter_end_found and ("UNIT_DIED" in log_entry or "0xa18" in log_entry) and "\""+boss.name+"\"" in log_entry:
+        if not boss.encounter_end_found and ("UNIT_DIED" in log_entry or ("0xa18" in log_entry and "Majordomo Executus" in log_entry)) and "\""+boss.name+"\"" in log_entry:
             write_segment_end(log_entry, boss, writer)
             boss.encounter_end_found = True
 


### PR DESCRIPTION
Fix for encounter of Majordomo Executus. Now it will shows *Kill* instead of *Wipe* on warcraftlogs. Before we tracked when Boss dies but it doesn't work correct for Majordomo Executus because he dies only after summoning Ragnaros.

Before:
![image](https://user-images.githubusercontent.com/121023853/220409761-5da5acfb-a79e-4831-b1ee-92df9d70ec2e.png)
After:
![image](https://user-images.githubusercontent.com/121023853/220409799-d8a2300f-ae91-4377-bf5d-74666e455700.png)

**Need to test on real wipes logs.**