### PR TITLE
Fix: correct end of Ragnaros encounter

### DIFF
--- a/monkey-tail.py
+++ b/monkey-tail.py
@@ -71,7 +71,7 @@ def fix_segmenting_start(log_entry, writer):
 def fix_segmenting_end(log_entry, writer):
     # 0xa18 — specific UnitFlag for Majordomo Executus's ends of encounter, the 1 indicates Majordomo turning friendly - see https://wowpedia.fandom.com/wiki/UnitFlag.
     for boss in boss_data:
-        if not boss.encounter_end_found and ("UNIT_DIED" in log_entry or ("0xa18" in log_entry and "Majordomo Executus" in log_entry)) and "\""+boss.name+"\"" in log_entry:
+        if not boss.encounter_end_found and ("UNIT_DIED" in log_entry or (boss.name == "Majordomo Executus" and "0xa18" in log_entry)) and "\""+boss.name+"\"" in log_entry:
             write_segment_end(log_entry, boss, writer)
             boss.encounter_end_found = True
 


### PR DESCRIPTION
There is the issue when in log line **Ragnaros** casts spell on **Majordomo Executus** with `0xa18` _UnitFlag_. For avoid it need to check current encounter name of boss.

Example:
```lua
0/0 00:00:00.167  ENCOUNTER_START,672,"Ragnaros",9,40
0/0 00:00:00.167  SPELL_CAST_START,Creature-0-1-0-0-11502-000026A438,"Ragnaros",0xa48,0x0,0000000000000000,nil,0x80000000,0x80000000,19773,"Elemental Fire",0x1
0/0 00:00:00.418  SPELL_PERIODIC_ENERGIZE,Player-1-000001DF,"Player-Everlook",0x514,0x0,Player-1-000001DF,"Player-Everlook",0x514,0x0,18194,"Mana Regeneration",0x1,0000000000000000,0000000000000000,0,0,0,0,0,-1,0,0,0,0.00,0.00,0,0.0000,0,8.0000,0.0000,0,0
0/0 00:00:00.520  SPELL_CAST_SUCCESS,Creature-0-1-0-0-11502-000026A438,"Ragnaros",0xa48,0x0,Creature-0-1-0-0-12018-000026A417,"Majordomo Executus",0xa18,0x0,19773,"Elemental Fire",0x1,0000000000000000,0000000000000000,0,0,0,0,0,-1,0,0,0,0.00,0.00,0,0.0000,0
0/0 00:00:00.520  ENCOUNTER_END,672,"Ragnaros",9,40,1
```
Before:
![image](https://user-images.githubusercontent.com/121023853/224266437-bfc0a718-5e85-4bac-af14-c96fab21b55e.png)

After:
![image](https://user-images.githubusercontent.com/121023853/224266746-7c3f043a-a70a-48ac-bd9a-fa988ddab1f6.png)